### PR TITLE
Fix website layout and css for github pages

### DIFF
--- a/draft/src/css/style.css
+++ b/draft/src/css/style.css
@@ -477,6 +477,10 @@ section:not(.hero-section) {
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: 30px;
     margin-top: 50px;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
 }
 
 .journey-card {
@@ -574,6 +578,9 @@ section:not(.hero-section) {
     gap: 30px;
     margin-top: 24px;
     width: 100%;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .trust-content {
@@ -1113,7 +1120,7 @@ footer::before {
         font-size: 1rem;
     }
 
-    .committee-cards, .trust-committee-cards {
+    .committee-cards {
         grid-template-columns: 1fr;
     }
 
@@ -1361,6 +1368,38 @@ footer::before {
     }
 }
 
+/* Large screen optimization */
+@media (min-width: 1400px) {
+    .trust-committee-cards {
+        grid-template-columns: repeat(3, 1fr);
+        gap: 40px;
+        max-width: 1400px;
+    }
+    
+    .journey-grid {
+        grid-template-columns: repeat(3, 1fr);
+        gap: 40px;
+    }
+    
+    .events-grid {
+        grid-template-columns: repeat(3, 1fr);
+        gap: 40px;
+    }
+}
+
+/* Tablet-specific breakpoint for better 3-column layouts */
+@media (max-width: 900px) {
+    .trust-committee-cards {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 25px;
+    }
+    
+    .journey-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 25px;
+    }
+}
+
 @media (max-width: 576px) {
     .hero-content h2 {
         font-size: 1.6rem;
@@ -1376,6 +1415,10 @@ footer::before {
     }
     
     .journey-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .trust-committee-cards {
         grid-template-columns: 1fr;
     }
     

--- a/draft/src/index.html
+++ b/draft/src/index.html
@@ -1,10 +1,40 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="refresh" content="0; url=pages/index.html" />
-    <title>Redirecting...</title>
+    <title>Shree Cutchi Leva Patel Samaj - Nairobi</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        text-align: center;
+        margin-top: 50px;
+        background-color: #f8f9fa;
+      }
+      .redirect-message {
+        background: white;
+        padding: 30px;
+        border-radius: 10px;
+        box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+        max-width: 400px;
+        margin: 0 auto;
+      }
+      .redirect-link {
+        color: #1a1a6c;
+        text-decoration: none;
+        font-weight: bold;
+      }
+      .redirect-link:hover {
+        text-decoration: underline;
+      }
+    </style>
   </head>
   <body>
-    <p>If you are not redirected automatically, <a href="pages/index.html">click here</a>.</p>
+    <div class="redirect-message">
+      <h1>Shree Cutchi Leva Patel Samaj</h1>
+      <p>Redirecting to main site...</p>
+      <p>If you are not redirected automatically, <a href="pages/index.html" class="redirect-link">click here</a>.</p>
+    </div>
   </body>
 </html>

--- a/draft/src/pages/board-and-management.html
+++ b/draft/src/pages/board-and-management.html
@@ -8,9 +8,6 @@
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/board-management.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
     <script src="../js/main.js" defer></script>
     <script src="../js/board-management.js" defer></script>

--- a/draft/src/pages/contact.html
+++ b/draft/src/pages/contact.html
@@ -6,8 +6,7 @@
   <title>Contact Us - Shree Cutchi Leva Patel Samaj, Nairobi</title>
       <link rel="stylesheet" href="../css/tailwind.css">
   <link rel="stylesheet" href="../css/style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="../js/main.js" defer></script>
 </head>
 <body>

--- a/draft/src/pages/create-event.html
+++ b/draft/src/pages/create-event.html
@@ -7,7 +7,6 @@
     <link rel="stylesheet" href="../css/tailwind.css">
   <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="../js/main.js" defer></script>
 </head>
 <body>

--- a/draft/src/pages/our-history.html
+++ b/draft/src/pages/our-history.html
@@ -6,8 +6,7 @@
   <title>Our History - Shree Cutchi Leva Patel Samaj, Nairobi</title>
       <link rel="stylesheet" href="../css/tailwind.css">
   <link rel="stylesheet" href="../css/style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="../js/main.js" defer></script>
 </head>
 <body>

--- a/draft/src/pages/past-events.html
+++ b/draft/src/pages/past-events.html
@@ -63,9 +63,24 @@
         
         .events-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
             gap: 30px;
             margin-bottom: 50px;
+        }
+        
+        /* Better responsive behavior for events grid */
+        @media (max-width: 992px) {
+            .events-grid {
+                grid-template-columns: repeat(2, 1fr);
+                gap: 25px;
+            }
+        }
+        
+        @media (max-width: 768px) {
+            .events-grid {
+                grid-template-columns: repeat(1, 1fr);
+                gap: 20px;
+            }
         }
         
         .event-card {

--- a/draft/src/pages/upcoming-events.html
+++ b/draft/src/pages/upcoming-events.html
@@ -43,9 +43,24 @@
         
         .events-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
             gap: 30px;
             margin-bottom: 50px;
+        }
+        
+        /* Better responsive behavior for events grid */
+        @media (max-width: 992px) {
+            .events-grid {
+                grid-template-columns: repeat(2, 1fr);
+                gap: 25px;
+            }
+        }
+        
+        @media (max-width: 768px) {
+            .events-grid {
+                grid-template-columns: repeat(1, 1fr);
+                gap: 20px;
+            }
         }
         
         .event-card {


### PR DESCRIPTION
Optimize CSS grid layouts and clean up HTML to ensure consistent 3-tile-per-row display and proper styling on GitHub Pages.

The previous CSS media queries caused the 3-column grid to collapse prematurely on certain screen sizes, leading to only 2 or 1 tile per row. Duplicate CSS link references also contributed to inconsistent styling. This PR refines the responsive breakpoints and removes redundant links for a robust GitHub Pages deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-4609005e-2239-4884-be18-db053da7537c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4609005e-2239-4884-be18-db053da7537c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

